### PR TITLE
#85 Feat: Job 스케줄링에서 Job 저장 트랜잭션을 분리한다.

### DIFF
--- a/src/main/java/next/career/domain/job/service/JobBatchService.java
+++ b/src/main/java/next/career/domain/job/service/JobBatchService.java
@@ -1,5 +1,6 @@
 package next.career.domain.job.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +13,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -22,6 +24,7 @@ public class JobBatchService {
     private final WebClient seoulJobClient;
     private final XmlMapper xmlMapper = new XmlMapper();
     private final JobRepository jobRepository;
+    private final JobService jobService;
 
     /**
      * 서울일자리포털 API에서 데이터 가져와 DB 저장
@@ -42,15 +45,7 @@ public class JobBatchService {
         log.info("xmlResposne = {}", xmlResponse);
 
         try {
-            SaveSeoulJobDto.Response response =
-                    xmlMapper.readValue(xmlResponse, SaveSeoulJobDto.Response.class);
-
-            log.info("saveseoul job dto response = {}", response);
-
-            List<Job> jobs = response.getSeoulJobDtoList().stream()
-                    .filter(dto -> !jobRepository.findAlreadyExists(dto.getJobTitle(), dto.getCompanyName()))
-                    .map(this::toEntity)
-                    .toList();
+            List<Job> jobs = parseAndConvertJobs(xmlResponse);
 
             return jobRepository.saveAll(jobs);
 
@@ -62,42 +57,62 @@ public class JobBatchService {
     @Transactional()
     public List<Job> fetchAndSaveJobsSchedule() {
 
-        try {
         LocalDate today = LocalDate.now();
         String todayStr = today.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
 
+        try {
+            List<Job> saveJobs = new ArrayList<>();
+            String seoulJobDataXmlResponse = getSeoulJobData();
+            List<Job> jobs = parseAndConvertJobs(seoulJobDataXmlResponse);
+            for (Job job : jobs) {
+                boolean isSuccess = jobService.saveJob(job);
+                if(isSuccess) {
+                    saveJobs.add(job);
+                }
+            }
+            return saveJobs;
+        } catch (Exception e) {
+            throw new RuntimeException("XML 파싱 실패", e);
+        }
+    }
+
+    private List<Job> parseAndConvertJobs(String xmlResponse) {
+        try {
+            SaveSeoulJobDto.Response response = xmlMapper.readValue(xmlResponse, SaveSeoulJobDto.Response.class);
+            log.info("서울일자리포털 응답 데이터 개수 = {}", response.getSeoulJobDtoList().size());
+            return filterAndConvertToEntity(response);
+        } catch (Exception e) {
+            throw new RuntimeException("XML 파싱 실패", e);
+        }
+    }
+
+    private List<Job> filterAndConvertToEntity(SaveSeoulJobDto.Response response) {
+        List<Job> jobs = response.getSeoulJobDtoList().stream()
+                .filter(dto -> !jobRepository.findAlreadyExists(dto.getJobTitle(), dto.getCompanyName()))
+                .map(this::toEntity)
+                .toList();
+        return jobs;
+    }
+
+    private String getSeoulJobData() {
         String xmlResponse = seoulJobClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/xml/GetJobInfo/{pageNo}/{numOfRows}/{id}/{area}/{occupation}/{edu}/{career}/{regDate}")
                         .build(
-                                0,
-                                999,
+                                7,
+                                100,
                                 "",
                                 "",
                                 "",
                                 "",
                                 "",
-                                "2025-09-17"
+                                "2025-08-18"
                         )
                 )
                 .retrieve()
                 .bodyToMono(String.class)
                 .block();
-
-
-            SaveSeoulJobDto.Response response =
-                    xmlMapper.readValue(xmlResponse, SaveSeoulJobDto.Response.class);
-
-            List<Job> jobs = response.getSeoulJobDtoList().stream()
-                    .filter(dto -> !jobRepository.findAlreadyExists(dto.getJobTitle(), dto.getCompanyName()))
-                    .map(this::toEntity)
-                    .toList();
-
-            return jobRepository.saveAll(jobs);
-
-        } catch (Exception e) {
-            throw new RuntimeException("XML 파싱 실패", e);
-        }
+        return xmlResponse;
     }
 
     private Job toEntity(SaveSeoulJobDto.SeoulJobDto dto) {
@@ -118,7 +133,25 @@ public class JobBatchService {
                 dto.getRequiredDocuments(),
                 dto.getJobCategory(),
                 dto.getPostingDate(),
-                dto.getClosingDate()
+                extractClosingDate(dto.getClosingDate())
         );
     }
+
+    private String extractClosingDate(String closingDate) {
+        if (closingDate == null || closingDate.isBlank()) {
+            return null;
+        }
+
+        // 괄호 안 날짜만 추출
+        int start = closingDate.indexOf("(");
+        int end = closingDate.indexOf(")");
+
+        if (start != -1 && end != -1 && start < end) {
+            return closingDate.substring(start + 1, end); // yyyy-MM-dd
+        }
+
+        // 괄호가 없으면 그대로 반환
+        return closingDate;
+    }
+
 }

--- a/src/main/java/next/career/domain/job/service/JobService.java
+++ b/src/main/java/next/career/domain/job/service/JobService.java
@@ -27,6 +27,7 @@ import next.career.global.apiPayload.exception.GlobalErrorType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -178,9 +179,16 @@ public class JobService {
         ));
     }
 
-
-
-
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public boolean saveJob(Job job) {
+        try {
+            jobRepository.save(job);
+            return true;
+        } catch (Exception e) {
+            log.warn("Job 저장 실패: {}, 사유: {}", job.getJobTitle(), e.getMessage());
+            return false;
+        }
+    }
 
     @Transactional
     public void answerAIChat(Integer sequence, String answer, Member member) {


### PR DESCRIPTION
## 기능 설명

일자리 공고 스케줄링 시 트랜잭션이 분리 되지 않아 한 건의 일자리 공고 데이터 저장에 실패한다면 모든 일자리 공고 저장이 실패함.
-> 각 일자리 저장마다 트랜잭션 분리
<br>

## 연결된 issue

close #85 
<br>

## Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
