### PR TITLE
#89 Fix: 21-jdk-slim image 지원 종료로 인해 image를 변경한다

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,5 +1,5 @@
 # 빌드 단계
-FROM openjdk:21-jdk-slim AS builder
+FROM eclipse-temurin:21-jdk-jammy AS builder
 WORKDIR /app
 COPY . .
 RUN ./gradlew build -x test


### PR DESCRIPTION
## 기능 설명

사유:
기존 openjdk:21-jdk-slim 이미지는 Docker Hub 공식 OpenJDK 리포지토리의 deprecated 정책에 따라 2025년 이후 삭제되어 더 이상 사용할 수 없습니다.
해당 이미지를 사용하던 Dockerfile 빌드 단계에서 not found 오류가 발생하여,
동일한 OpenJDK 기반의 공식 후속 이미지인 eclipse-temurin:21-jdk-jammy로 교체하였습니다.

효과:

OpenJDK 21 기반 유지 (기능 동일)

Temurin(Adoptium) 프로젝트는 OpenJDK의 공식 후속 이식판으로, 장기적으로 안정적이고 보안 업데이트를 지속 지원

CI/CD 및 Docker 빌드 정상화<br>

## 연결된 issue

close #{}
<br>

## Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
