### PR TITLE
#94 Fix: 강점 리포트 기획 개선 사항을 반영한다

### DIFF
--- a/src/main/java/next/career/domain/openai/service/ConvertService.java
+++ b/src/main/java/next/career/domain/openai/service/ConvertService.java
@@ -3,6 +3,8 @@ package next.career.domain.openai.service;
 import lombok.RequiredArgsConstructor;
 import next.career.domain.job.controller.dto.GetRoadMapDto;
 import next.career.domain.user.entity.MemberDetail;
+import next.career.global.apiPayload.exception.CoreException;
+import next.career.global.apiPayload.exception.GlobalErrorType;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -27,6 +29,10 @@ public class ConvertService {
 
     public String convertMemberDetailToText(MemberDetail memberDetail) {
         StringBuilder sb = new StringBuilder();
+
+        if(memberDetail == null){
+            throw new CoreException(GlobalErrorType.MEMBER_DETAIL_IS_NULL);
+        }
 
         if (memberDetail.getExperience() != null && !memberDetail.getExperience().isBlank()) {
             sb.append("경험: ").append(memberDetail.getExperience()).append("\n");

--- a/src/main/java/next/career/domain/openai/service/OpenAiService.java
+++ b/src/main/java/next/career/domain/openai/service/OpenAiService.java
@@ -523,6 +523,7 @@ public class OpenAiService {
                                                         "properties", Map.of(
                                                                 "strength", Map.of("type", "string"),
                                                                 "experience", Map.of("type", "string"),
+                                                                "appeal", Map.of("type", "string"),
                                                                 "keyword", Map.of(
                                                                         "type", "array",
                                                                         "items", Map.of("type", "string")
@@ -532,7 +533,13 @@ public class OpenAiService {
                                                                         "items", Map.of("type", "string")
                                                                 )
                                                         ),
-                                                        "required", List.of("strength", "experience", "keyword", "job")
+                                                        "required", List.of(
+                                                                "strength",
+                                                                "experience",
+                                                                "appeal",
+                                                                "keyword",
+                                                                "job"
+                                                        )
                                                 )
                                         )
                                 ),
@@ -549,4 +556,5 @@ public class OpenAiService {
                 "response_format", responseFormat
         );
     }
+
 }

--- a/src/main/java/next/career/domain/report/controller/ReportController.java
+++ b/src/main/java/next/career/domain/report/controller/ReportController.java
@@ -9,10 +9,7 @@ import next.career.domain.user.entity.Member;
 import next.career.global.apiPayload.response.ApiResponse;
 import next.career.global.security.AuthDetails;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -55,6 +52,17 @@ public class ReportController {
     ) {
         Member member = authDetails.getUser();
         return ApiResponse.success(reportService.getStrengthReportCurrentHistory(member));
+    }
+
+    @DeleteMapping("/strength/{strengthReportId}")
+    public ApiResponse<?> deleteStrengthReport(
+            @Parameter(hidden = true, description = "인증된 사용자 정보")
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @PathVariable Long strengthReportId
+    ) {
+        Member member = authDetails.getUser();
+        reportService.deleteStrengthReport(member, strengthReportId);
+        return ApiResponse.success();
     }
 
 }

--- a/src/main/java/next/career/domain/report/controller/ReportController.java
+++ b/src/main/java/next/career/domain/report/controller/ReportController.java
@@ -48,4 +48,13 @@ public class ReportController {
         return ApiResponse.success(reportService.getStrengthReport(member));
     }
 
+    @GetMapping("/strength/history")
+    public ApiResponse<GetStrengthReportDto.Response> getStrengthReportHistory(
+            @Parameter(hidden = true, description = "인증된 사용자 정보")
+            @AuthenticationPrincipal AuthDetails authDetails
+    ) {
+        Member member = authDetails.getUser();
+        return ApiResponse.success(reportService.getStrengthReportCurrentHistory(member));
+    }
+
 }

--- a/src/main/java/next/career/domain/report/controller/dto/GetStrengthReportDto.java
+++ b/src/main/java/next/career/domain/report/controller/dto/GetStrengthReportDto.java
@@ -32,13 +32,15 @@ public class GetStrengthReportDto {
         private String experience;
         private List<String> keyword;
         private List<String> job;
+        private String appeal;
 
-        public static Report of(String strength, String experience, List<String> keyword, List<String> job){
+        public static Report of(String strength, String experience, List<String> keyword, List<String> job, String appeal){
             return Report.builder()
                     .strength(strength)
                     .experience(experience)
                     .keyword(keyword)
                     .job(job)
+                    .appeal(appeal)
                     .build();
         }
     }

--- a/src/main/java/next/career/domain/report/controller/dto/GetStrengthReportDto.java
+++ b/src/main/java/next/career/domain/report/controller/dto/GetStrengthReportDto.java
@@ -28,14 +28,16 @@ public class GetStrengthReportDto {
     @AllArgsConstructor
     @Builder
     public static class Report{
+        private Long strengthReportId;
         private String strength;
         private String experience;
         private List<String> keyword;
         private List<String> job;
         private String appeal;
 
-        public static Report of(String strength, String experience, List<String> keyword, List<String> job, String appeal){
+        public static Report of(Long reportId, String strength, String experience, List<String> keyword, List<String> job, String appeal){
             return Report.builder()
+                    .strengthReportId(reportId)
                     .strength(strength)
                     .experience(experience)
                     .keyword(keyword)

--- a/src/main/java/next/career/domain/report/entity/StrengthReport.java
+++ b/src/main/java/next/career/domain/report/entity/StrengthReport.java
@@ -41,8 +41,10 @@ public class StrengthReport {
     @Column(columnDefinition = "json")
     private List<String> job;
 
+    private int version;
+
     public static StrengthReport of(Member member, String strength, String experience,
-                                    List<String> keyword, List<String> job, String appeal) {
+                                    List<String> keyword, List<String> job, String appeal, int version) {
         return StrengthReport.builder()
                 .member(member)
                 .strength(strength)
@@ -50,6 +52,7 @@ public class StrengthReport {
                 .keyword(keyword)
                 .job(job)
                 .appeal(appeal)
+                .version(version)
                 .build();
     }
 }

--- a/src/main/java/next/career/domain/report/entity/StrengthReport.java
+++ b/src/main/java/next/career/domain/report/entity/StrengthReport.java
@@ -43,6 +43,8 @@ public class StrengthReport {
 
     private int version;
 
+    boolean isDeleted = false;
+
     public static StrengthReport of(Member member, String strength, String experience,
                                     List<String> keyword, List<String> job, String appeal, int version) {
         return StrengthReport.builder()
@@ -54,5 +56,9 @@ public class StrengthReport {
                 .appeal(appeal)
                 .version(version)
                 .build();
+    }
+
+    public void markAsDeleted() {
+        this.isDeleted = true;
     }
 }

--- a/src/main/java/next/career/domain/report/entity/StrengthReport.java
+++ b/src/main/java/next/career/domain/report/entity/StrengthReport.java
@@ -30,6 +30,9 @@ public class StrengthReport {
 
     private String experience;
 
+    @Column(columnDefinition = "TEXT")
+    private String appeal;
+
     @Type(JsonType.class)
     @Column(columnDefinition = "json")
     private List<String> keyword;
@@ -39,13 +42,14 @@ public class StrengthReport {
     private List<String> job;
 
     public static StrengthReport of(Member member, String strength, String experience,
-                                    List<String> keyword, List<String> job) {
+                                    List<String> keyword, List<String> job, String appeal) {
         return StrengthReport.builder()
                 .member(member)
                 .strength(strength)
                 .experience(experience)
                 .keyword(keyword)
                 .job(job)
+                .appeal(appeal)
                 .build();
     }
 }

--- a/src/main/java/next/career/domain/report/repository/StrengthReportRepository.java
+++ b/src/main/java/next/career/domain/report/repository/StrengthReportRepository.java
@@ -17,4 +17,6 @@ public interface StrengthReportRepository extends JpaRepository<StrengthReport, 
 
     @Query("SELECT MAX(sr.version) FROM StrengthReport sr WHERE sr.member = :member")
     Optional<Integer> findMaxVersionByMember(@Param("member") Member member);
+
+    List<StrengthReport> findAllByMember(Member member);
 }

--- a/src/main/java/next/career/domain/report/repository/StrengthReportRepository.java
+++ b/src/main/java/next/career/domain/report/repository/StrengthReportRepository.java
@@ -3,6 +3,8 @@ package next.career.domain.report.repository;
 import next.career.domain.report.entity.StrengthReport;
 import next.career.domain.user.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,4 +14,7 @@ public interface StrengthReportRepository extends JpaRepository<StrengthReport, 
     void deleteAllByMember(Member member);
 
     List<StrengthReport> findAllByMember(Member member);
+
+    @Query("SELECT MAX(sr.version) FROM StrengthReport sr WHERE sr.member = :member")
+    Optional<Integer> findMaxVersionByMember(@Param("member") Member member);
 }

--- a/src/main/java/next/career/domain/report/repository/StrengthReportRepository.java
+++ b/src/main/java/next/career/domain/report/repository/StrengthReportRepository.java
@@ -13,7 +13,7 @@ public interface StrengthReportRepository extends JpaRepository<StrengthReport, 
 
     void deleteAllByMember(Member member);
 
-    List<StrengthReport> findAllByMember(Member member);
+    List<StrengthReport> findAllByMemberAndIsDeletedFalse(Member member);
 
     @Query("SELECT MAX(sr.version) FROM StrengthReport sr WHERE sr.member = :member")
     Optional<Integer> findMaxVersionByMember(@Param("member") Member member);

--- a/src/main/java/next/career/domain/report/service/ReportService.java
+++ b/src/main/java/next/career/domain/report/service/ReportService.java
@@ -6,6 +6,8 @@ import next.career.domain.report.controller.dto.GetStrengthReportDto;
 import next.career.domain.report.entity.StrengthReport;
 import next.career.domain.report.repository.StrengthReportRepository;
 import next.career.domain.user.entity.Member;
+import next.career.global.apiPayload.exception.CoreException;
+import next.career.global.apiPayload.exception.GlobalErrorType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,6 +53,7 @@ public class ReportService {
 
         List<GetStrengthReportDto.Report> reportList = strengthReportList.stream()
                 .map(r -> GetStrengthReportDto.Report.of(
+                        r.getStrengthReportId(),
                         r.getStrength(),
                         r.getExperience(),
                         r.getKeyword(),
@@ -78,6 +81,7 @@ public class ReportService {
 
         List<GetStrengthReportDto.Report> reportList = latestReports.stream()
                 .map(r -> GetStrengthReportDto.Report.of(
+                        r.getStrengthReportId(),
                         r.getStrength(),
                         r.getExperience(),
                         r.getKeyword(),
@@ -88,5 +92,17 @@ public class ReportService {
 
 
         return GetStrengthReportDto.Response.of(reportList);
+    }
+
+    @Transactional
+    public void deleteStrengthReport(Member member, Long strengthReportId) {
+        StrengthReport strengthReport = strengthReportRepository.findById(strengthReportId)
+                .orElseThrow(() -> new CoreException(GlobalErrorType.STRENGTH_REPORT_NOT_FOUND));
+
+        if(strengthReport.getMember() != member) {
+            throw new CoreException(GlobalErrorType.FORBIDDEN);
+        }
+
+        strengthReport.markAsDeleted();
     }
 }

--- a/src/main/java/next/career/domain/report/service/ReportService.java
+++ b/src/main/java/next/career/domain/report/service/ReportService.java
@@ -21,7 +21,12 @@ public class ReportService {
 
     @Transactional
     public GetStrengthReportDto.Response createStrengthReport(Member member) {
+        Integer latestVersion = strengthReportRepository.findMaxVersionByMember(member)
+                .orElse(0);
+
         GetStrengthReportDto.Response response = openAiService.createStrengthReport(member);
+
+        int newVersion = latestVersion + 1;
 
         List<StrengthReport> reports = response.getReportList().stream()
                 .map(r -> StrengthReport.of(
@@ -30,15 +35,14 @@ public class ReportService {
                         r.getExperience(),
                         r.getKeyword(),
                         r.getJob(),
-                        r.getAppeal()
+                        r.getAppeal(),
+                        newVersion
                 ))
                 .toList();
 
         strengthReportRepository.saveAll(reports);
 
         return response;
-
-
     }
 
     public GetStrengthReportDto.Response getStrengthReport(Member member) {

--- a/src/main/java/next/career/domain/report/service/ReportService.java
+++ b/src/main/java/next/career/domain/report/service/ReportService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -99,7 +100,7 @@ public class ReportService {
         StrengthReport strengthReport = strengthReportRepository.findById(strengthReportId)
                 .orElseThrow(() -> new CoreException(GlobalErrorType.STRENGTH_REPORT_NOT_FOUND));
 
-        if(strengthReport.getMember() != member) {
+        if(!Objects.equals(strengthReport.getMember().getId(), member.getId())){
             throw new CoreException(GlobalErrorType.FORBIDDEN);
         }
 

--- a/src/main/java/next/career/domain/report/service/ReportService.java
+++ b/src/main/java/next/career/domain/report/service/ReportService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -45,6 +46,33 @@ public class ReportService {
         List<StrengthReport> strengthReportList = strengthReportRepository.findAllByMember(member);
 
         List<GetStrengthReportDto.Report> reportList = strengthReportList.stream()
+                .map(r -> GetStrengthReportDto.Report.of(
+                        r.getStrength(),
+                        r.getExperience(),
+                        r.getKeyword(),
+                        r.getJob()
+                        , r.getAppeal()
+                ))
+                .toList();
+
+
+        return GetStrengthReportDto.Response.of(reportList);
+    }
+
+    public GetStrengthReportDto.Response getStrengthReportCurrentHistory(Member member) {
+
+        List<StrengthReport> strengthReportList = strengthReportRepository.findAllByMember(member);
+
+        int latestVersion = strengthReportList.stream()
+                .mapToInt(StrengthReport::getVersion)
+                .max()
+                .orElse(0);
+
+        List<StrengthReport> latestReports = strengthReportList.stream()
+                .filter(r -> r.getVersion() == latestVersion)
+                .toList();
+
+        List<GetStrengthReportDto.Report> reportList = latestReports.stream()
                 .map(r -> GetStrengthReportDto.Report.of(
                         r.getStrength(),
                         r.getExperience(),

--- a/src/main/java/next/career/domain/report/service/ReportService.java
+++ b/src/main/java/next/career/domain/report/service/ReportService.java
@@ -49,7 +49,7 @@ public class ReportService {
 
     public GetStrengthReportDto.Response getStrengthReport(Member member) {
 
-        List<StrengthReport> strengthReportList = strengthReportRepository.findAllByMember(member);
+        List<StrengthReport> strengthReportList = strengthReportRepository.findAllByMemberAndIsDeletedFalse(member);
 
         List<GetStrengthReportDto.Report> reportList = strengthReportList.stream()
                 .map(r -> GetStrengthReportDto.Report.of(
@@ -68,7 +68,7 @@ public class ReportService {
 
     public GetStrengthReportDto.Response getStrengthReportCurrentHistory(Member member) {
 
-        List<StrengthReport> strengthReportList = strengthReportRepository.findAllByMember(member);
+        List<StrengthReport> strengthReportList = strengthReportRepository.findAllByMemberAndIsDeletedFalse(member);
 
         int latestVersion = strengthReportList.stream()
                 .mapToInt(StrengthReport::getVersion)

--- a/src/main/java/next/career/domain/report/service/ReportService.java
+++ b/src/main/java/next/career/domain/report/service/ReportService.java
@@ -22,8 +22,6 @@ public class ReportService {
     public GetStrengthReportDto.Response createStrengthReport(Member member) {
         GetStrengthReportDto.Response response = openAiService.createStrengthReport(member);
 
-        strengthReportRepository.deleteAllByMember(member);
-
         List<StrengthReport> reports = response.getReportList().stream()
                 .map(r -> StrengthReport.of(
                         member,

--- a/src/main/java/next/career/domain/report/service/ReportService.java
+++ b/src/main/java/next/career/domain/report/service/ReportService.java
@@ -28,7 +28,8 @@ public class ReportService {
                         r.getStrength(),
                         r.getExperience(),
                         r.getKeyword(),
-                        r.getJob()
+                        r.getJob(),
+                        r.getAppeal()
                 ))
                 .toList();
 
@@ -49,6 +50,7 @@ public class ReportService {
                         r.getExperience(),
                         r.getKeyword(),
                         r.getJob()
+                        , r.getAppeal()
                 ))
                 .toList();
 

--- a/src/main/java/next/career/domain/report/service/ReportService.java
+++ b/src/main/java/next/career/domain/report/service/ReportService.java
@@ -69,7 +69,7 @@ public class ReportService {
 
     public GetStrengthReportDto.Response getStrengthReportCurrentHistory(Member member) {
 
-        List<StrengthReport> strengthReportList = strengthReportRepository.findAllByMemberAndIsDeletedFalse(member);
+        List<StrengthReport> strengthReportList = strengthReportRepository.findAllByMember(member);
 
         int latestVersion = strengthReportList.stream()
                 .mapToInt(StrengthReport::getVersion)

--- a/src/main/java/next/career/global/apiPayload/exception/GlobalErrorType.java
+++ b/src/main/java/next/career/global/apiPayload/exception/GlobalErrorType.java
@@ -49,7 +49,7 @@ public enum GlobalErrorType implements ErrorType {
     // Strength Report
     STRENGTH_REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "강점 리포트를 찾을 수 없습니다"),
 
-    ;
+    MEMBER_DETAIL_IS_NULL(HttpStatus.BAD_REQUEST, "먼저 채팅을 진행해야 합니다.");
 
     private final HttpStatus status;
 

--- a/src/main/java/next/career/global/apiPayload/exception/GlobalErrorType.java
+++ b/src/main/java/next/career/global/apiPayload/exception/GlobalErrorType.java
@@ -44,7 +44,10 @@ public enum GlobalErrorType implements ErrorType {
 
     MEMBER_OCCUPATION_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "추천 직업이 존재하지 않습니다"),
 
-    GET_STRENGTH_REPORT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "강점 리포트 생성에 실패했습니다")
+    GET_STRENGTH_REPORT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "강점 리포트 생성에 실패했습니다"),
+
+    // Strength Report
+    STRENGTH_REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "강점 리포트를 찾을 수 없습니다"),
 
     ;
 


### PR DESCRIPTION
## 기능 설명

AS-IS
- 강점 리포트 생성 시 기존 강점 리포트 삭제
- 강점 리포트 생성 시 AI 채팅 실시 하지 않았으면 500에러 반환

TO-BE
- 강점 리포트 생성 시 기존 강점 리포트 남아있고 새로운 강점 리포트 추가
- 강점 리포트 삭제 기능 추가
- 가장 최근에 생성한 강점 리포트 조회 기능 추가
- 강점 리포트 생성 시 AI 채팅 실시 하지 않았으면 400에러 반환

<br>

## 연결된 issue

close #94 
<br>

## Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
